### PR TITLE
fix: skip nodes without Vultr provider ID in lifecycle checks

### DIFF
--- a/vultr/instancesv2.go
+++ b/vultr/instancesv2.go
@@ -32,6 +32,13 @@ func newInstancesV2(client *govultr.Client) cloudprovider.InstancesV2 {
 
 // InstanceExists return bool whether or not the instance exists
 func (i *instancesv2) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
+	// Nodes without a Vultr provider ID are not managed by this CCM.
+	// Treat them as existing to prevent the node lifecycle controller
+	// from deleting them when they become NotReady.
+	if node.Spec.ProviderID == "" {
+		return true, nil
+	}
+
 	newNode, err := i.getVultrInstance(ctx, node)
 	if err != nil {
 		log.Printf("instance(%s) exists check failed: %e", node.Spec.ProviderID, err) //nolint
@@ -53,6 +60,10 @@ func (i *instancesv2) InstanceExists(ctx context.Context, node *v1.Node) (bool, 
 
 // InstanceShutdown returns bool whether or not the instance is running or powered off
 func (i *instancesv2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
+	if node.Spec.ProviderID == "" {
+		return false, nil
+	}
+
 	newNode, err := i.getVultrInstance(ctx, node)
 	if err != nil {
 		log.Printf("instance(%s) shutdown check failed: %e", node.Spec.ProviderID, err) //nolint
@@ -67,6 +78,10 @@ func (i *instancesv2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool
 
 // InstanceMetadata returns a struct of type InstanceMetadata containing the node information
 func (i *instancesv2) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
+	if node.Spec.ProviderID == "" {
+		return nil, fmt.Errorf("node %s has no provider ID, not managed by Vultr", node.Name)
+	}
+
 	newNode, err := i.getVultrInstance(ctx, node)
 	if err != nil {
 		log.Printf("instance(%s) metadata check failed: %e", node.Spec.ProviderID, err) //nolint


### PR DESCRIPTION
## Summary
- Nodes without a `vultr://` provider ID are not managed by this CCM
- `InstanceExists` now returns `true` for unmanaged nodes, preventing the node lifecycle controller from deleting them when they go NotReady
- `InstanceShutdown` returns `false` (not shutdown) for unmanaged nodes
- `InstanceMetadata` returns an error for unmanaged nodes since we can't provide Vultr metadata

## Context
In a hybrid cluster with both Vultr and on-premise nodes, the CCM would look up non-Vultr node names in the Vultr API, get "not found", and delete the node object. This is destructive for on-premise nodes that temporarily go NotReady.

## Test plan
- [x] Existing tests pass
- [ ] Deploy to hybrid cluster, verify on-premise nodes are not deleted when NotReady