### PR TITLE
fix: update Alpine to 3.21.3 and unpin ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# renovate: datasource=docker depName=golang
 FROM golang:1.20-alpine AS build
 
 WORKDIR /workspace
@@ -7,8 +8,9 @@ ARG VERSION
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=$VERSION" -o vultr-cloud-controller-manager .
 
-FROM alpine:3.19.0
-RUN apk add --no-cache ca-certificates=20230506-r0
+# renovate: datasource=docker depName=alpine
+FROM alpine:3.21.3
+RUN apk add --no-cache ca-certificates
 
 COPY --from=build /workspace/vultr-cloud-controller-manager /vultr-cloud-controller-manager
 ENTRYPOINT ["/vultr-cloud-controller-manager"]

--- a/vultr/instancesv2.go
+++ b/vultr/instancesv2.go
@@ -32,6 +32,13 @@ func newInstancesV2(client *govultr.Client) cloudprovider.InstancesV2 {
 
 // InstanceExists return bool whether or not the instance exists
 func (i *instancesv2) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
+	// Nodes without a Vultr provider ID are not managed by this CCM.
+	// Treat them as existing to prevent the node lifecycle controller
+	// from deleting them when they become NotReady.
+	if node.Spec.ProviderID == "" {
+		return true, nil
+	}
+
 	newNode, err := i.getVultrInstance(ctx, node)
 	if err != nil {
 		log.Printf("instance(%s) exists check failed: %e", node.Spec.ProviderID, err) //nolint
@@ -53,6 +60,10 @@ func (i *instancesv2) InstanceExists(ctx context.Context, node *v1.Node) (bool, 
 
 // InstanceShutdown returns bool whether or not the instance is running or powered off
 func (i *instancesv2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
+	if node.Spec.ProviderID == "" {
+		return false, nil
+	}
+
 	newNode, err := i.getVultrInstance(ctx, node)
 	if err != nil {
 		log.Printf("instance(%s) shutdown check failed: %e", node.Spec.ProviderID, err) //nolint
@@ -67,6 +78,10 @@ func (i *instancesv2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool
 
 // InstanceMetadata returns a struct of type InstanceMetadata containing the node information
 func (i *instancesv2) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
+	if node.Spec.ProviderID == "" {
+		return nil, fmt.Errorf("node %s has no provider ID, not managed by Vultr", node.Name)
+	}
+
 	newNode, err := i.getVultrInstance(ctx, node)
 	if err != nil {
 		log.Printf("instance(%s) metadata check failed: %e", node.Spec.ProviderID, err) //nolint


### PR DESCRIPTION
## Summary
- Bump Alpine from 3.19.0 to 3.21.3 (pinned version of ca-certificates no longer available)
- Unpin ca-certificates to use latest from Alpine repos
- Add Renovate datasource comments for golang and alpine base images

## Context
Release pipeline failed because `ca-certificates=20230506-r0` is no longer in Alpine 3.19 repos.