### PR TITLE
fix: pin ca-certificates version for hadolint compliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w -X 
 
 # renovate: datasource=docker depName=alpine
 FROM alpine:3.21.3
-RUN apk add --no-cache ca-certificates
+# renovate: datasource=repology depName=alpine_3_21/ca-certificates
+RUN apk add --no-cache ca-certificates=20250911-r0
 
 COPY --from=build /workspace/vultr-cloud-controller-manager /vultr-cloud-controller-manager
 ENTRYPOINT ["/vultr-cloud-controller-manager"]


### PR DESCRIPTION
## Summary
- Pin `ca-certificates=20250911-r0` for hadolint DL3018 compliance
- Add Renovate datasource comment for automated version tracking